### PR TITLE
Fix LFS downloads with GitHub App tokens

### DIFF
--- a/gh_download/__init__.py
+++ b/gh_download/__init__.py
@@ -202,11 +202,27 @@ def _download_single_file(
         )
         return False
 
+    # Check if this is an LFS download URL
+    # LFS URLs use media.githubusercontent.com or contain /storage/lfs/
+    is_lfs_url = "media.githubusercontent.com" in download_url or "/storage/lfs/" in download_url
+
     # Update headers for raw file download
-    raw_download_headers = {
-        "Authorization": headers["Authorization"],
-        "Accept": "application/octet-stream",
-    }
+    if is_lfs_url:
+        # For LFS files, don't include Authorization header to avoid duplicate auth
+        # The LFS server provides its own RemoteAuth token in the download URL
+        raw_download_headers = {
+            "Accept": "application/octet-stream",
+        }
+        if not quiet:
+            console.print(
+                "🔐 Downloading LFS file without GitHub token (LFS auth handled separately)",
+            )
+    else:
+        # For regular files, include the Authorization header
+        raw_download_headers = {
+            "Authorization": headers["Authorization"],
+            "Accept": "application/octet-stream",
+        }
 
     return _download_and_save_file(
         download_url,


### PR DESCRIPTION
GitHub Apps send duplicate Authorization headers for LFS downloads which causes the LFS server to reject requests with 400 Bad Request. This is a known issue documented in actions/checkout#415.

The fix detects LFS download URLs (media.githubusercontent.com or /storage/lfs/) and removes the Authorization header for those requests, since the LFS server provides its own RemoteAuth token in the URL.

This matches the workaround used in actions/checkout which does: git -c 'http.../storage/lfs/.extraHeader=' lfs pull